### PR TITLE
Added functionality to only send order confirmation email upon RESERVED or CAPTURED

### DIFF
--- a/Model/Config/OrderStatus.php
+++ b/Model/Config/OrderStatus.php
@@ -1,0 +1,15 @@
+<?php
+namespace Sparxpres\Websale\Model\Config;
+
+use Magento\Framework\Option\ArrayInterface;
+
+class OrderStatus implements ArrayInterface {
+
+	public function toOptionArray() {
+		return [
+			['value' => 'reserved', 'label' => __('Reserved')],
+			['value' => 'captured', 'label' => __('Captured')]
+		];
+	}
+
+}

--- a/Observer/SalesOrderPlaceAfter.php
+++ b/Observer/SalesOrderPlaceAfter.php
@@ -1,34 +1,43 @@
 <?php
-
 namespace Sparxpres\Websale\Observer;
 
-use Magento\Sales\Model\Order;
+use Sparxpres\Websale\Model\SparxpresPaymentMethod;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
 
-class SalesOrderPlaceAfter implements \Magento\Framework\Event\ObserverInterface
+class SalesOrderPlaceAfter implements ObserverInterface
 {
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
 
     /**
-     *
+     * @param OrderRepositoryInterface $orderRepository
+     */
+    public function __construct(OrderRepositoryInterface $orderRepository)
+    {
+        $this->orderRepository = $orderRepository;
+    }
+
+    /**
      * @param \Magento\Framework\Event\Observer $observer
      * @return $this
      */
-    public function execute(\Magento\Framework\Event\Observer $observer)
+    public function execute(Observer $observer)
     {
         try {
             $order = $observer->getEvent()->getOrder();
-            if ($order instanceof \Magento\Framework\Model\AbstractModel) {
-                $paymentMethod = $order->getPayment()->getMethodInstance()->getCode();
-                if ($paymentMethod == \Sparxpres\Websale\Model\SparxpresPaymentMethod::PAYMENT_METHOD_CODE ||
-                    $paymentMethod == \Sparxpres\Websale\Model\XpresPayPaymentMethod::PAYMENT_METHOD_CODE) {
-                    $order->setState(Order::STATE_PENDING_PAYMENT)->setStatus(Order::STATE_PENDING_PAYMENT);
-                    $order->save();
-                }
+            $paymentMethod = $order->getPayment()->getMethodInstance()->getCode();
+            if ($paymentMethod == SparxpresPaymentMethod::PAYMENT_METHOD_CODE) {
+                $order->setCanSendNewEmailFlag(false);
+                $this->orderRepository->save($order);
             }
         } catch (\Exception $e) {
-            // ignored
+             // ignored
         }
 
         return $this;
     }
-
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -35,7 +35,6 @@
 					<validate>no-whitespace validate-hex-color-code</validate>
 				</field>
 			</group>
-
 			<group id="sparxpres_payment" translate="label" type="text" sortOrder="501" showInDefault="1" showInWebsite="1" showInStore="1">
 				<label>Sparxpres part payment</label>
 				<field id="active" translate="label" type="select" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="0">
@@ -57,8 +56,12 @@
 					<label>New order status</label>
 					<source_model>Magento\Sales\Model\Config\Source\Order\Status\NewStatus</source_model>
 				</field>
+				<field id="order_confirmation_email" translate="label" type="select" sortOrder="50" showInDefault="1" showInWebsite="1" showInStore="1">
+					<label>Order confirmation email</label>
+					<comment>Choose which callback should result in the order confirmation email being sent</comment>
+					<source_model>Sparxpres\Websale\Model\Config\OrderStatus</source_model>
+				</field>
 			</group>
-
 			<group id="xprespay_payment" translate="label" type="text" sortOrder="502" showInDefault="1" showInWebsite="1" showInStore="1">
 				<label>Sparxpres XpresPay</label>
 				<field id="active" translate="label" type="select" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="0">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -12,6 +12,7 @@ Følg anvisningerne på næste side.</instructions>
 				<group>offline</group>
 				<currency>DKK</currency>
 				<min_order_total>2000.0</min_order_total>
+				<order_confirmation_email>reserved</order_confirmation_email>
 				<!--can_initialize>0</can_initialize>
 				<can_use_checkout>1</can_use_checkout>
 				<can_authorize>1</can_authorize>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -3,7 +3,7 @@
 	<event name="payment_method_is_active">
 		<observer name="Sparxpres_Websale_PaymentAvailableCheck" instance="Sparxpres\Websale\Observer\PaymentAvailableCheck" />
 	</event>
-	<!--event name="sales_order_place_after">
+	<event name="sales_order_place_after">
 		<observer name="Sparxpres_Websale_SalesOrderPlaceAfter" instance="Sparxpres\Websale\Observer\SalesOrderPlaceAfter" />
-	</event-->
+	</event>
 </config>

--- a/i18n/da_DK.csv
+++ b/i18n/da_DK.csv
@@ -26,3 +26,5 @@ Enabled,Aktiv
 "Please enter a valid hex color code (# followed by 3 or 6 hexadecimal digits)","Indtast en gyldig hex-farvekode (# efterfulgt af 3 eller 6 hexadecimale cifre)"
 "Title", "Titel"
 "Instructions", "Instruktioner"
+"Choose which callback should result in the order confirmation email being sent","Vælg hvilket callback som skal resultere i at ordrebekræftelsen sendes"
+"Order confirmation email","Ordrebekræftelse email"

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -26,3 +26,5 @@ Enabled,Enabled
 "Please enter a valid hex color code (# followed by 3 or 6 hexadecimal digits)","Please enter a valid hex color code (# followed by 3 or 6 hexadecimal digits)"
 "Title", "Title"
 "Instructions", "Instructions"
+"Choose which callback should result in the order confirmation email being sent","Choose which callback should result in the order confirmation email being sent"
+"Order confirmation email","Order confirmation email"


### PR DESCRIPTION
* Implemented functionality to stop order confirmation email from being sent when directed from the checkout to the sparxpres payment gateway (including xpresspay). 
* Implemented functionality and backend setting to define if the order confirmation email should be sent upon callback RESERVED or CAPTURED.